### PR TITLE
[Fixed] Language not initialized on start of scenes

### DIFF
--- a/AfroPenguin & The Forbidden Ramen v1.0/Assets/Resources.meta
+++ b/AfroPenguin & The Forbidden Ramen v1.0/Assets/Resources.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b642b9fcbdda2e74e8d5fd3ea4565e1b
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/AfroPenguin & The Forbidden Ramen v1.0/Assets/Resources/Main.prefab
+++ b/AfroPenguin & The Forbidden Ramen v1.0/Assets/Resources/Main.prefab
@@ -1,0 +1,45 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &9200728683185671424
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5807545734004705869}
+  - component: {fileID: 7976609956815296516}
+  m_Layer: 0
+  m_Name: Main
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5807545734004705869
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9200728683185671424}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &7976609956815296516
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9200728683185671424}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 87c3494c401e5244e81a2f122121b2f9, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/AfroPenguin & The Forbidden Ramen v1.0/Assets/Resources/Main.prefab.meta
+++ b/AfroPenguin & The Forbidden Ramen v1.0/Assets/Resources/Main.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 750d0ad496145ca4c9f7ecf7fe4b1f65
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/AfroPenguin & The Forbidden Ramen v1.0/Assets/Scripts/ContinueAndFadeScreens.cs
+++ b/AfroPenguin & The Forbidden Ramen v1.0/Assets/Scripts/ContinueAndFadeScreens.cs
@@ -15,7 +15,7 @@ public class ContinueAndFadeScreens : MonoBehaviour
     void Start()
     {
         FadeFromBlack();
-        switch (LanguageSelect.instance.language)
+        switch (PlayerPrefs.GetInt("Language"))
         {
             case 1:
                 GameObject[] englishGameObjects = GameObject.FindGameObjectsWithTag("English Text");
@@ -27,8 +27,8 @@ public class ContinueAndFadeScreens : MonoBehaviour
                 break;
 
             default:
-                GameObject[] españolGameObjects = GameObject.FindGameObjectsWithTag("Español Text");
-                foreach (GameObject go in españolGameObjects)
+                GameObject[] espaÃ±olGameObjects = GameObject.FindGameObjectsWithTag("EspaÃ±ol Text");
+                foreach (GameObject go in espaÃ±olGameObjects)
                 {
                     go.SetActive(false);
                 }
@@ -58,7 +58,7 @@ public class ContinueAndFadeScreens : MonoBehaviour
                 shouldFadeFromBlack = false;
             }
         }
-        
+
         if (Input.anyKeyDown)
         {
             SceneManager.LoadSceneAsync(sceneName);

--- a/AfroPenguin & The Forbidden Ramen v1.0/Assets/Scripts/LanguageMassiveController.cs
+++ b/AfroPenguin & The Forbidden Ramen v1.0/Assets/Scripts/LanguageMassiveController.cs
@@ -7,7 +7,7 @@ public class LanguageMassiveController : MonoBehaviour
     // Start is called before the first frame update
     void Start()
     {
-        switch (LanguageSelect.instance.language)
+        switch (PlayerPrefs.GetInt("Language"))
         {
             case 1:
                 GameObject[] englishGameObjects = GameObject.FindGameObjectsWithTag("English Text");
@@ -19,8 +19,8 @@ public class LanguageMassiveController : MonoBehaviour
                 break;
 
             default:
-                GameObject[] españolGameObjects = GameObject.FindGameObjectsWithTag("Español Text");
-                foreach (GameObject go in españolGameObjects)
+                GameObject[] espaÃ±olGameObjects = GameObject.FindGameObjectsWithTag("EspaÃ±ol Text");
+                foreach (GameObject go in espaÃ±olGameObjects)
                 {
                     go.SetActive(false);
                 }
@@ -32,6 +32,6 @@ public class LanguageMassiveController : MonoBehaviour
     // Update is called once per frame
     void Update()
     {
-        
+
     }
 }

--- a/AfroPenguin & The Forbidden Ramen v1.0/Assets/Scripts/LanguageSelect.cs
+++ b/AfroPenguin & The Forbidden Ramen v1.0/Assets/Scripts/LanguageSelect.cs
@@ -6,15 +6,10 @@ using UnityEngine.UI;
 
 public class LanguageSelect : MonoBehaviour
 {
-    public static LanguageSelect instance;
     public int language;
     public Image fadeScreen;
     public float fadeSpeed = 1.0f;
     public bool shouldFadeToBlack, shouldFadeFromBlack;
-    private void Awake()
-    {
-        instance = this;
-    }
 
     public void Start()
     {
@@ -45,14 +40,12 @@ public class LanguageSelect : MonoBehaviour
     public void EnglishLanguage()
     {
         PlayerPrefs.SetInt("Language", 0);
-        language = PlayerPrefs.GetInt("Language");
         SceneManager.LoadScene("Main Menu");
     }
 
     public void SpanishLanguage()
     {
         PlayerPrefs.SetInt("Language", 1);
-        language = PlayerPrefs.GetInt("Language");
         SceneManager.LoadScene("Main Menu");
     }
 

--- a/AfroPenguin & The Forbidden Ramen v1.0/Assets/Scripts/LevelManager.cs
+++ b/AfroPenguin & The Forbidden Ramen v1.0/Assets/Scripts/LevelManager.cs
@@ -24,7 +24,7 @@ public class LevelManager : MonoBehaviour
     public void Start()
     {
         isPlayingLevelEnd = false;
-        switch (LanguageSelect.instance.language)
+        switch (PlayerPrefs.GetInt("Language"))
         {
             case 1:
                 GameObject[] englishGameObjects = GameObject.FindGameObjectsWithTag("English Text");
@@ -36,8 +36,8 @@ public class LevelManager : MonoBehaviour
                 break;
 
             default:
-                GameObject[] españolGameObjects = GameObject.FindGameObjectsWithTag("Español Text");
-                foreach (GameObject go in españolGameObjects)
+                GameObject[] espaÃ±olGameObjects = GameObject.FindGameObjectsWithTag("EspaÃ±ol Text");
+                foreach (GameObject go in espaÃ±olGameObjects)
                 {
                     go.SetActive(false);
                 }
@@ -74,7 +74,7 @@ public class LevelManager : MonoBehaviour
     //this is a coroutine. It happens outside the normal time of Unity. LESSON 41 WITH JAMES DOYLE.
     public IEnumerator RespawnCo()
     {
-        //FindObjectOfType<PlayerController>().transform.parent = null; // Borré esto porque tiraba error. Checkear bien con algo de Enero 2022.
+        //FindObjectOfType<PlayerController>().transform.parent = null; // Borrï¿½ esto porque tiraba error. Checkear bien con algo de Enero 2022.
         PlayerController.instance.gameObject.SetActive(false);
         //AudioManager.instance.PlaySFX(8);
         yield return new WaitForSeconds(waitToRespawn - (1.0f / UIController.instance.fadeSpeed));

--- a/AfroPenguin & The Forbidden Ramen v1.0/Assets/Scripts/Main.cs
+++ b/AfroPenguin & The Forbidden Ramen v1.0/Assets/Scripts/Main.cs
@@ -1,0 +1,15 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class Main : MonoBehaviour
+{
+    // Runs before a scene gets loaded
+    [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.BeforeSceneLoad)]
+    public static void LoadMain()
+    {
+        GameObject main = GameObject.Instantiate(Resources.Load("Main")) as GameObject;
+        GameObject.DontDestroyOnLoad(main);
+        PlayerPrefs.SetInt("Language", 0);
+    }
+}

--- a/AfroPenguin & The Forbidden Ramen v1.0/Assets/Scripts/Main.cs.meta
+++ b/AfroPenguin & The Forbidden Ramen v1.0/Assets/Scripts/Main.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 87c3494c401e5244e81a2f122121b2f9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/AfroPenguin & The Forbidden Ramen v1.0/Assets/Scripts/MainMenu.cs
+++ b/AfroPenguin & The Forbidden Ramen v1.0/Assets/Scripts/MainMenu.cs
@@ -17,9 +17,9 @@ public class MainMenu : MonoBehaviour
     void Start()
     {
         FadeFromBlack();
-        switch (LanguageSelect.instance.language)
+        switch (PlayerPrefs.GetInt("Language"))
         {
-            case 1: 
+            case 1:
                 GameObject[] englishGameObjects = GameObject.FindGameObjectsWithTag("English Text");
                 foreach (GameObject go in englishGameObjects)
                 {
@@ -28,15 +28,15 @@ public class MainMenu : MonoBehaviour
                 break;
 
             default:
-                GameObject[] españolGameObjects = GameObject.FindGameObjectsWithTag("Español Text");
-                foreach (GameObject go in españolGameObjects)
+                GameObject[] espaÃ±olGameObjects = GameObject.FindGameObjectsWithTag("EspaÃ±ol Text");
+                foreach (GameObject go in espaÃ±olGameObjects)
                 {
                     go.SetActive(false);
                 }
                 break;
         }
 
-        if (PlayerPrefs.HasKey(startScene+ "_unlocked"))
+        if (PlayerPrefs.HasKey(startScene + "_unlocked"))
         {
             continueButton.SetActive(true);
         }
@@ -72,7 +72,6 @@ public class MainMenu : MonoBehaviour
     {
         SceneManager.LoadScene(startScene);
         PlayerPrefs.DeleteAll();
-        PlayerPrefs.SetInt("Language", LanguageSelect.instance.language);
     }
 
     public void QuitGame()

--- a/AfroPenguin & The Forbidden Ramen v1.0/Assets/Scripts/WorldmapUIController.cs
+++ b/AfroPenguin & The Forbidden Ramen v1.0/Assets/Scripts/WorldmapUIController.cs
@@ -11,7 +11,7 @@ public class WorldmapUIController : MonoBehaviour
     public bool shouldFadeToBlack, shouldFadeFromBlack;
     public GameObject levelInfoPanel;
     public Text levelName, livesLost, starsCollected, bestTime;
-    
+
     private void Awake()
     {
         instance = this;
@@ -20,7 +20,7 @@ public class WorldmapUIController : MonoBehaviour
     void Start()
     {
         FadeFromBlack();
-        switch (LanguageSelect.instance.language)
+        switch (PlayerPrefs.GetInt("Language"))
         {
             case 1:
                 GameObject[] englishGameObjects = GameObject.FindGameObjectsWithTag("English Text");
@@ -32,8 +32,8 @@ public class WorldmapUIController : MonoBehaviour
                 break;
 
             default:
-                GameObject[] españolGameObjects = GameObject.FindGameObjectsWithTag("Español Text");
-                foreach (GameObject go in españolGameObjects)
+                GameObject[] espaÃ±olGameObjects = GameObject.FindGameObjectsWithTag("EspaÃ±ol Text");
+                foreach (GameObject go in espaÃ±olGameObjects)
                 {
                     go.SetActive(false);
                 }
@@ -78,7 +78,7 @@ public class WorldmapUIController : MonoBehaviour
 
     public void ShowLevelInfo(WorldmapPoint worldMapPointLevelInfo) //I'm giving you the WorldmapPoint variable to use to get information. LevelInfo is made up.
     {
-        switch (LanguageSelect.instance.language)
+        switch (PlayerPrefs.GetInt("Language"))
         {
             case 1:
                 levelName.text = worldMapPointLevelInfo.levelNameSpanish;

--- a/AfroPenguin & The Forbidden Ramen v1.0/Packages/manifest.json
+++ b/AfroPenguin & The Forbidden Ramen v1.0/Packages/manifest.json
@@ -1,10 +1,10 @@
 {
   "dependencies": {
-    "com.unity.2d.animation": "5.0.10",
+    "com.unity.2d.animation": "5.2.0",
     "com.unity.2d.pixel-perfect": "4.0.1",
-    "com.unity.2d.psdimporter": "4.1.3",
+    "com.unity.2d.psdimporter": "4.3.0",
     "com.unity.2d.sprite": "1.0.0",
-    "com.unity.2d.spriteshape": "5.1.7",
+    "com.unity.2d.spriteshape": "5.3.0",
     "com.unity.2d.tilemap": "1.0.0",
     "com.unity.collab-proxy": "1.15.18",
     "com.unity.ide.rider": "2.0.7",

--- a/AfroPenguin & The Forbidden Ramen v1.0/Packages/packages-lock.json
+++ b/AfroPenguin & The Forbidden Ramen v1.0/Packages/packages-lock.json
@@ -1,11 +1,11 @@
 {
   "dependencies": {
     "com.unity.2d.animation": {
-      "version": "5.0.10",
+      "version": "5.2.0",
       "depth": 0,
       "source": "registry",
       "dependencies": {
-        "com.unity.2d.common": "4.0.4",
+        "com.unity.2d.common": "4.2.0",
         "com.unity.mathematics": "1.1.0",
         "com.unity.2d.sprite": "1.0.0",
         "com.unity.modules.animation": "1.0.0",
@@ -14,7 +14,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.2d.common": {
-      "version": "4.0.4",
+      "version": "4.2.0",
       "depth": 1,
       "source": "registry",
       "dependencies": {
@@ -38,12 +38,12 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.2d.psdimporter": {
-      "version": "4.1.3",
+      "version": "4.3.0",
       "depth": 0,
       "source": "registry",
       "dependencies": {
-        "com.unity.2d.common": "4.0.4",
-        "com.unity.2d.animation": "5.0.10",
+        "com.unity.2d.common": "4.2.0",
+        "com.unity.2d.animation": "5.2.0",
         "com.unity.2d.sprite": "1.0.0"
       },
       "url": "https://packages.unity.com"
@@ -55,12 +55,12 @@
       "dependencies": {}
     },
     "com.unity.2d.spriteshape": {
-      "version": "5.1.7",
+      "version": "5.3.0",
       "depth": 0,
       "source": "registry",
       "dependencies": {
         "com.unity.mathematics": "1.1.0",
-        "com.unity.2d.common": "4.0.4",
+        "com.unity.2d.common": "4.2.0",
         "com.unity.2d.path": "4.0.2",
         "com.unity.modules.physics2d": "1.0.0"
       },

--- a/AfroPenguin & The Forbidden Ramen v1.0/ProjectSettings/ProjectVersion.txt
+++ b/AfroPenguin & The Forbidden Ramen v1.0/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 2020.3.27f1
-m_EditorVersionWithRevision: 2020.3.27f1 (e759542391ea)
+m_EditorVersion: 2020.3.35f1
+m_EditorVersionWithRevision: 2020.3.35f1 (18e4db7a9996)

--- a/AfroPenguin & The Forbidden Ramen v1.0/UserSettings/EditorUserSettings.asset
+++ b/AfroPenguin & The Forbidden Ramen v1.0/UserSettings/EditorUserSettings.asset
@@ -6,34 +6,34 @@ EditorUserSettings:
   serializedVersion: 4
   m_ConfigSettings:
     RecentlyUsedScenePath-0:
-      value: 22424703114646680e0b0227036c7003171c196a1f3c333424260e7df7ee3d2cfb
-      flags: 0
-    RecentlyUsedScenePath-1:
-      value: 22424703114646680e0b0227036c73150012146a7c7868252320092a
-      flags: 0
-    RecentlyUsedScenePath-2:
-      value: 22424703114646680e0b0227036c731118100d2b2b2d68252320092a
-      flags: 0
-    RecentlyUsedScenePath-3:
-      value: 22424703114646680e0b0227036c7a13191b172d3566333e243d04
-      flags: 0
-    RecentlyUsedScenePath-4:
       value: 22424703114646680e0b0227036c7c021313113e3f686b707d7b5326ece92021
       flags: 0
-    RecentlyUsedScenePath-5:
+    RecentlyUsedScenePath-1:
       value: 22424703114646680e0b0227036c7c021313113e3f686b707d785326ece92021
       flags: 0
-    RecentlyUsedScenePath-6:
-      value: 22424703114646680e0b0227036c72111f1958072926337e38271427fb
-      flags: 0
-    RecentlyUsedScenePath-7:
+    RecentlyUsedScenePath-2:
       value: 22424703114646680e0b0227036c73150012146a7c7b68252320092a
       flags: 0
-    RecentlyUsedScenePath-8:
+    RecentlyUsedScenePath-3:
       value: 22424703114646680e0b0227036c73150012146a7c7968252320092a
       flags: 0
-    RecentlyUsedScenePath-9:
+    RecentlyUsedScenePath-4:
+      value: 22424703114646680e0b0227036c7a13191b172d3566333e243d04
+      flags: 0
+    RecentlyUsedScenePath-5:
       value: 22424703114646680e0b0227036c73150012146a7c7a68252320092a
+      flags: 0
+    RecentlyUsedScenePath-6:
+      value: 22424703114646680e0b0227036c6f02133b172b28687661633c133af6f9
+      flags: 0
+    RecentlyUsedScenePath-7:
+      value: 22424703114646680e0b0227036c731118100d2b2b2d68252320092a
+      flags: 0
+    RecentlyUsedScenePath-8:
+      value: 22424703114646680e0b0227036c72111f1958072926337e38271427fb
+      flags: 0
+    RecentlyUsedScenePath-9:
+      value: 22424703114646680e0b0227036c7003171c196a1f3c333424260e7df7ee3d2cfb
       flags: 0
     vcSharedLogLevel:
       value: 0d5e400f0650


### PR DESCRIPTION
This is my proposed solution to the problem that language is not initialized when you load a scene.

- Created a Main prefab in the Resources directory, and attached a script that is always initialized first before any scene is loaded. I initialize the PlayerPrefs "Language" to 0. You can initialize other stuff there.
- I removed the singleton part of the "LanguageSelect" script since the instance is not needed anymore.
- "ñ" characters were not showed properly in my pc, I think maybe they werent uft-8
- I had to open this project with unity 2020.3.35f1 since I didn't have a 2020 unity version installed and this one was the only 2020 version that y could download. Is only a few minor versions after your unity version.